### PR TITLE
Fix: Remove incorrect device class from Flow Rate sensor

### DIFF
--- a/custom_components/ecowitt_iot/sensor.py
+++ b/custom_components/ecowitt_iot/sensor.py
@@ -64,7 +64,6 @@ WFC01_SENSORS = [
         key="flow_rate",
         name="Flow Rate",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
-        device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn="flow_velocity",
         entity_registry_enabled_default=True,


### PR DESCRIPTION
Removes the `device_class=SensorDeviceClass.WATER` assignment from the 'Flow Rate' sensor definition (`key="flow_rate"`) in `custom_components/ecowitt_iot/sensor.py`.

This resolves a  warning caused by using a flow rate unit ('L/min') with a device class intended for volume measurements. Removing the device class allows the sensor to function correctly without the warning.