### PR TITLE
Fix JSONDecodeError in config flow

### DIFF
--- a/custom_components/ecowitt_iot/translations/en.json
+++ b/custom_components/ecowitt_iot/translations/en.json
@@ -13,7 +13,8 @@
       "cannot_connect": "Failed to connect to device",
       "timeout_connect": "Connection timeout",
       "no_devices": "No devices found",
-      "invalid_host": "Invalid IP address"
+      "invalid_host": "Invalid IP address",
+      "invalid_response": "The device returned an invalid or empty response. Please check the device's status, configuration, and network connection. Check the Home Assistant logs for the raw response."
     },
     "abort": {
       "already_configured": "Device is already configured"


### PR DESCRIPTION
Improved error handling in the Ecowitt IoT config flow to prevent crashes caused by invalid or empty responses from the device's /get_iot_device_list endpoint.

Changes:
- Added checks in `validate_input` to detect empty responses or responses that look like HTML before attempting JSON parsing.
- Raised specific `ValueError` exceptions for different invalid data scenarios (empty response, HTML, bad JSON, unexpected format).
- Updated `async_step_user` to catch these specific `ValueError`s and map them to a new `invalid_response` error key.
- Added the `invalid_response` error key and a user-friendly message to the `en.json` translation file.

This provides clearer feedback to you when the device returns unexpected data, rather than showing a generic connection error.