### PR TITLE
Fix: Correct Ecowitt connection terminology

### DIFF
--- a/custom_components/ecowitt_iot/strings.json
+++ b/custom_components/ecowitt_iot/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Ecowitt IoT Device",
-        "description": "Set up your Ecowitt IoT device to monitor and control.",
+        "title": "Connect to Ecowitt Gateway/Hub",
+        "description": "Set up your Ecowitt gateway/hub to monitor and control connected devices.",
         "data": {
           "host": "IP Address or Hostname"
         }
@@ -17,12 +17,12 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect",
+      "cannot_connect": "Failed to connect to the gateway/hub",
       "timeout_connect": "Connection timeout",
       "invalid_host": "Invalid hostname or IP address"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Gateway/Hub is already configured"
     }
   }
 }

--- a/custom_components/ecowitt_iot/translations/en.json
+++ b/custom_components/ecowitt_iot/translations/en.json
@@ -2,22 +2,22 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Ecowitt IoT Device",
-        "description": "Enter the IP address of your Ecowitt IoT device",
+        "title": "Connect to Ecowitt Gateway/Hub",
+        "description": "Enter the IP address of your Ecowitt gateway/hub",
         "data": {
           "host": "IP Address"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to device",
+      "cannot_connect": "Failed to connect to the gateway/hub",
       "timeout_connect": "Connection timeout",
       "no_devices": "No devices found",
       "invalid_host": "Invalid IP address",
-      "invalid_response": "The device returned an invalid or empty response. Please check the device's status, configuration, and network connection. Check the Home Assistant logs for the raw response."
+      "invalid_response": "The gateway/hub returned an invalid or empty response. Please check the device's status, configuration, and network connection. Check the Home Assistant logs for the raw response."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Gateway/Hub is already configured"
     }
   },
   "entity": {


### PR DESCRIPTION
The user interface previously referred to connecting to an "Ecowitt IoT Device" when setting up the integration. This is inaccurate, as the connection is made to the Ecowitt gateway/hub device, which then communicates with the individual IoT sensors.

This commit updates the user-facing strings in `strings.json` and `en.json` to use the more accurate terms "Gateway/Hub" instead of "IoT Device" or generic "Device" where appropriate. This improves clarity for you during the configuration process.